### PR TITLE
fix seedtime

### DIFF
--- a/src/pyrosimple/torrent/engine.py
+++ b/src/pyrosimple/torrent/engine.py
@@ -51,15 +51,18 @@ def _interval_split(
     An exaple of the input is "R1283008245P1283008268".
     Returns events in reversed order (latest first).
     """
-
+   
+            
     def split_event(event):
         "Helper to parse events."
         kind, val = event[:1], event[1:]
+        print
         try:
             return kind, float(val)
         except (TypeError, ValueError):
             return None, 0
-
+    if hasattr(interval, "fetch"):
+        interval = interval.fetch("custom_activations")   
     return list(
         reversed(
             [

--- a/src/pyrosimple/torrent/engine.py
+++ b/src/pyrosimple/torrent/engine.py
@@ -56,7 +56,6 @@ def _interval_split(
     def split_event(event):
         "Helper to parse events."
         kind, val = event[:1], event[1:]
-        print
         try:
             return kind, float(val)
         except (TypeError, ValueError):


### PR DESCRIPTION
I was unable to get seedtime to work, and I believe this bug would effect leechtime. 

Looking through the code, it seems that this functionality is the same as it was in the python2 pyrocore. I was able to utilize the same syntax in pyrosimple

One thing though is that the program crash for me without the if statement that I added.
So I'm not sure how helpful it is. As from what I can tell either the fetch attr is present, and a valid value is retried or the program crashes

Crash trashback
```
Traceback (most recent call last):
  File "/root/.local/bin/rtcontrol", line 8, in <module>
    sys.exit(run())
  File "/root/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/scripts/rtcontrol.py", line 898, in run
    RtorrentControl().run()
  File "/root/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/scripts/base.py", line 180, in run
    self.mainloop()
  File "/root/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/scripts/rtcontrol.py", line 712, in mainloop
    matches = futures[url].get()
  File "/usr/lib/python3.10/multiprocessing/pool.py", line 771, in get
    raise self._value
  File "/usr/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/root/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/scripts/rtcontrol.py", line 703, in fetch
    matches = list(e.items(view=view, prefetch=prefetch))
  File "/root/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/torrent/rtorrent.py", line 831, in items
    if view.matcher.match(ritem):
  File "/root/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/util/matching.py", line 148, in match
    return all(c.match(item) for c in self.children)
  File "/root/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/util/matching.py", line 148, in <genexpr>
    return all(c.match(item) for c in self.children)
  File "/root/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/util/matching.py", line 690, in match
    if getattr(item, self._name) is None:
  File "/root/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/torrent/engine.py", line 248, in __get__
    self._accessor(obj) if self._accessor else obj._fields[self.name]
  File "/root/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/torrent/engine.py", line 623, in <lambda>
    accessor=lambda o: _interval_sum(o, start=o.completed)
  File "/root/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/torrent/engine.py", line 92, in _interval_sum
    events = _interval_split(interval)
  File "/root/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/torrent/engine.py", line 70, in _interval_split
    for i in event_re.findall(interval)
TypeError: expected string or bytes-like object
```
