### PR TITLE
chtor: Fix `--reannounce-all` without `--no-cross-seed`

### DIFF
--- a/src/pyrosimple/scripts/chtor.py
+++ b/src/pyrosimple/scripts/chtor.py
@@ -304,7 +304,7 @@ class MetafileChanger(ScriptBase):
                     if not self.options.no_cross_seed:
                         # Enforce unique hash per tracker
                         torrent["info"]["x_cross_seed"] = hashlib.md5(
-                            self.options.reannounce
+                            self.options.reannounce.encode()
                         ).hexdigest()
                 if self.options.no_ssl:
                     # We're assuming here the same (default) port is used


### PR DESCRIPTION
This fixes the following error when running `chtor --reannounce-all` without specifying `--no-cross-seed`:
```
Traceback (most recent call last):                                                   
  File "/home/nyuszika7h/.local/bin/chtor", line 8, in <module>
    sys.exit(run())                                                                  
  File "/home/nyuszika7h/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/scripts/chtor.py", line 400, in run
    MetafileChanger().run()                                                          
  File "/home/nyuszika7h/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/scripts/base.py", line 180, in run
    self.mainloop()                                                                  
  File "/home/nyuszika7h/.local/pipx/venvs/pyrosimple/lib/python3.10/site-packages/pyrosimple/scripts/chtor.py", line 306, in mainloop
    torrent["info"]["x_cross_seed"] = hashlib.md5(       
TypeError: Strings must be encoded before hashing        
```