### PR TITLE
Fix the create-config and create-rtorrent-rc commands

### DIFF
--- a/src/pyrosimple/scripts/pyroadmin.py
+++ b/src/pyrosimple/scripts/pyroadmin.py
@@ -15,11 +15,11 @@ import tomli_w
 import pyrosimple
 
 from pyrosimple import config
-from pyrosimple.scripts.base import ScriptBaseWithConfig
+from pyrosimple.scripts.base import ScriptBase
 from pyrosimple.util import matching
 
 
-class AdminTool(ScriptBaseWithConfig):
+class AdminTool(ScriptBase):
     """Support for administrative tasks."""
 
     # TODO: config create, dump, set, get
@@ -27,6 +27,7 @@ class AdminTool(ScriptBaseWithConfig):
 
     def add_options(self):
         super().add_options()
+        self.parser.add_argument("-U", "--url", help="URL to rtorrent instance")
         self.parser.set_defaults(func=None)
         subparsers = self.parser.add_subparsers()
         config_parser = subparsers.add_parser("config", help="Validate configuration")


### PR DESCRIPTION
Previously they would fail as if the config files did not already exist.

Running `pyroadmin config --create-rtorrent-rc` would result in a stack trace like:

```
Traceback (most recent call last):
  File "/nix/store/nqyha84673a4950hgk0b2c81mvbahvqc-python3.10-pyrosimple-2.6.1/lib/python3.10/site-packages/pyrosimple/scripts/base.py", line 170, in run
    self.get_options()
  File "/nix/store/nqyha84673a4950hgk0b2c81mvbahvqc-python3.10-pyrosimple-2.6.1/lib/python3.10/site-packages/pyrosimple/scripts/base.py", line 243, in get_options
    self.engine = rtorrent.RtorrentEngine()
  File "/nix/store/nqyha84673a4950hgk0b2c81mvbahvqc-python3.10-pyrosimple-2.6.1/lib/python3.10/site-packages/pyrosimple/torrent/rtorrent.py", line 643, in __init__
    config.autoload_scgi_url()
  File "/nix/store/nqyha84673a4950hgk0b2c81mvbahvqc-python3.10-pyrosimple-2.6.1/lib/python3.10/site-packages/pyrosimple/config.py", line 124, in autoload_scgi_url
    raise error.UserError(f"rTorrent RC file '{rcfile}' doesn't exist!")
pyrosimple.error.UserError: rTorrent RC file '/home/madiath/.rtorrent.rc' doesn't exist!
```

From what I can tell, the commands here don't need the config version of the base class.
They create their own engine instance, and don't rely on the engine created in `ScriptBaseWithConfig`