### PR TITLE
fix create_config's incorrect config_path

### DIFF
--- a/src/pyrosimple/scripts/pyroadmin.py
+++ b/src/pyrosimple/scripts/pyroadmin.py
@@ -238,7 +238,7 @@ class AdminTool(ScriptBase):
 
     def create_config(self):
         """Create a configuration file"""
-        config_path = Path(config.settings.CONFIG)
+        config_path = Path(config.SETTINGS_FILE)
         if config_path.exists():
             self.log.info(
                 "Pyrosimple config path %s already exists, not overwriting", config_path


### PR DESCRIPTION
As per #30: running `pyroadmin --verbose config --create-config` is still problematic.
```
INFO:pyrosimple.scripts.pyroadmin.AdminTool:Total time: 0.010 seconds.
Traceback (most recent call last):
  File "box/box.py", line 587, in box.box.Box.__getitem__
KeyError: 'CONFIG'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "box/box.py", line 620, in box.box.Box.__getattr__
  File "box/box.py", line 608, in box.box.Box.__getitem__
box.exceptions.BoxKeyError: "'CONFIG'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "box/box.py", line 622, in box.box.Box.__getattr__
AttributeError: 'Box' object has no attribute 'CONFIG'. Did you mean: 'CONFIG_PY'?

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.10/pyroadmin", line 8, in <module>
    sys.exit(run())
  File "/usr/lib/python3.10/site-packages/pyrosimple/scripts/pyroadmin.py", line 352, in run
    AdminTool().run()
  File "/usr/lib/python3.10/site-packages/pyrosimple/scripts/base.py", line 177, in run
    self.mainloop()
  File "/usr/lib/python3.10/site-packages/pyrosimple/scripts/pyroadmin.py", line 347, in mainloop
    self.options.func()
  File "/usr/lib/python3.10/site-packages/pyrosimple/scripts/pyroadmin.py", line 275, in config
    self.create_config()
  File "/usr/lib/python3.10/site-packages/pyrosimple/scripts/pyroadmin.py", line 241, in create_config
    config_path = Path(config.settings.CONFIG)
  File "box/box.py", line 636, in box.box.Box.__getattr__
box.exceptions.BoxKeyError: "'Box' object has no attribute 'CONFIG'"
```  
This is caused by:
https://github.com/kannibalox/pyrosimple/blob/c05ac2fc60de48a5153b50de14114c5e673df1f3/src/pyrosimple/scripts/pyroadmin.py#L241
The `config.settings.CONFIG` variable doesn't exist.  

Having looked into where the default config is created, we already have a variable that defines where this toml file is supposed to be:
https://github.com/kannibalox/pyrosimple/blob/157adf98e8e1a84362e8a23a743b0f823e982f75/src/pyrosimple/config.py#L29

This patch uses `SETTINGS_FILE` variable instead.